### PR TITLE
Fixed Ubuntu/Linux Mint compilation problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,10 @@ EXECUTABLE=ncgrep
 
 all: $(SOURCES) $(EXECUTABLE)
 
+
+# -lncurses needs to be at end off compilation command
 $(EXECUTABLE): $(OBJECTS) 
-	$(CC) $(LDFLAGS) $(OBJECTS) -o $@
+	$(CC) $(LDFLAGS) $(OBJECTS) -o $@ -lncurses
 
 .cpp.o:
 	$(CC) $(CFLAGS) $< -o $@

--- a/files.cpp
+++ b/files.cpp
@@ -1,4 +1,5 @@
 #include <string>
+#include <cstring>
 #include <sys/types.h>
 #include <dirent.h>
 #include <vector>


### PR DESCRIPTION
Found linking entire package requires (at least in Linux Mint) having "-lncurses" at end of compilation command.